### PR TITLE
fix: resolve hostname and strip port in WireGuard peer detection

### DIFF
--- a/src/killswitch/network.rs
+++ b/src/killswitch/network.rs
@@ -8,7 +8,7 @@
 use crate::cli::verbosity::Verbosity;
 use crate::killswitch::is_private_ip;
 use anyhow::{Context, Result, bail};
-use std::net::IpAddr;
+use std::net::{IpAddr, ToSocketAddrs};
 use std::process::Command;
 
 // ============================================================================
@@ -228,18 +228,51 @@ fn detect_peer_from_scutil(verbose: Verbosity) -> Result<String> {
 
         let detail = String::from_utf8_lossy(&show_output.stdout);
 
-        // Look for "RemoteAddress : <ip>"
+        // Look for "RemoteAddress : <host>[:<port>]"
         for detail_line in detail.lines() {
             let trimmed = detail_line.trim();
-            if let Some(ip) = trimmed.strip_prefix("RemoteAddress : ") {
-                let ip = ip.trim();
-                if is_valid_vpn_peer(ip) {
-                    if verbose.is_verbose() {
-                        eprintln!("  Detected VPN peer via scutil: {ip}");
+            if let Some(raw) = trimmed.strip_prefix("RemoteAddress : ") {
+                let raw = raw.trim();
+                // Strip optional port suffix (host:port or [ipv6]:port)
+                let host = if raw.starts_with('[') {
+                    raw.trim_start_matches('[').split(']').next().unwrap_or(raw)
+                } else {
+                    raw.splitn(2, ':').next().unwrap_or(raw)
+                };
+
+                // Resolve hostname to IP if needed
+                let resolved = if host.parse::<IpAddr>().is_ok() {
+                    host.to_string()
+                } else {
+                    if verbose.is_debug() {
+                        eprintln!("  Resolving hostname: {host}");
                     }
-                    return Ok(ip.to_string());
+                    match format!("{host}:0").to_socket_addrs() {
+                        Ok(mut addrs) => match addrs.find(|a| a.is_ipv4()) {
+                            Some(addr) => addr.ip().to_string(),
+                            None => {
+                                if verbose.is_debug() {
+                                    eprintln!("  No IPv4 address for: {host}");
+                                }
+                                continue;
+                            }
+                        },
+                        Err(e) => {
+                            if verbose.is_debug() {
+                                eprintln!("  DNS resolution failed for {host}: {e}");
+                            }
+                            continue;
+                        }
+                    }
+                };
+
+                if is_valid_vpn_peer(&resolved) {
+                    if verbose.is_verbose() {
+                        eprintln!("  Detected VPN peer via scutil: {resolved}");
+                    }
+                    return Ok(resolved);
                 } else if verbose.is_debug() {
-                    eprintln!("  Skipping non-public RemoteAddress: {ip}");
+                    eprintln!("  Skipping non-public RemoteAddress: {resolved}");
                 }
             }
         }


### PR DESCRIPTION
## Summary

- Strip the `:port` suffix from `RemoteAddress` values reported by `scutil` (handles both `host:port` and `[ipv6host]:port` forms)
- Resolve hostnames to IPv4 via DNS when the address is not a bare IP
- Allows killswitch to function correctly when a WireGuard peer uses a dynamic hostname and a custom port

Fixes #35

## Test plan

- [ ] WireGuard config with `Endpoint = hostname:port` — confirm killswitch detects the peer and applies firewall rules
- [ ] WireGuard config with `Endpoint = 1.2.3.4` (bare IP, no port) — confirm existing behaviour is unchanged
- [ ] WireGuard config with `Endpoint = 1.2.3.4:51820` (IP with port) — confirm port is stripped correctly
- [ ] WireGuard config with `Endpoint = [::1]:51820` (IPv6 with port) — confirm bracket stripping works

🤖 Generated with [Claude Code](https://claude.com/claude-code)