### PR TITLE
fix(ci): checkout full PR ref

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
   test:
     uses: ./.github/workflows/test.yml
     with:
-      branch: ${{ github.ref_name }}
+      branch: ${{ github.ref }}
 
   build:
     name: Build


### PR DESCRIPTION
## Summary

Pass the full `github.ref` to the reusable test workflow instead of `github.ref_name`.

For pull requests, `github.ref_name` is `<number>/merge`. Checkout interprets that value as `refs/heads/<number>/merge`, which does not exist. The full ref preserves GitHub's actual `refs/pull/<number>/merge` path.

## Testing

- confirmed PR #37's standalone Test workflow passes
- confirmed its Build workflow fails only while fetching `refs/heads/37/merge`
- verified the workflow diff and whitespace

Refs #37

- [x] Have you tested the code?
- [x] Have you checked that the existing tests are passing?
- [x] The destination branch is **develop**